### PR TITLE
dts: phytec: phycore_rt1170: Add DAC support for phycore_rt1170

### DIFF
--- a/drivers/dac/CMakeLists.txt
+++ b/drivers/dac/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_DAC_MCUX_LPDAC	dac_mcux_lpdac.c)
 zephyr_library_sources_ifdef(CONFIG_DAC_MCUX_DAC	dac_mcux_dac.c)
+zephyr_library_sources_ifdef(CONFIG_DAC_MCUX_DAC12	dac_mcux_dac12.c)
 zephyr_library_sources_ifdef(CONFIG_DAC_MCUX_DAC32	dac_mcux_dac32.c)
 zephyr_library_sources_ifdef(CONFIG_DAC_STM32		dac_stm32.c)
 zephyr_library_sources_ifdef(CONFIG_DAC_SAM		dac_sam.c)

--- a/drivers/dac/Kconfig.mcux
+++ b/drivers/dac/Kconfig.mcux
@@ -11,6 +11,13 @@ config DAC_MCUX_DAC
 	help
 	  Enable the driver for the NXP Kinetis MCUX DAC.
 
+config DAC_MCUX_DAC12
+	bool "NXP Kinetis MCUX DAC12 driver"
+	default y
+	depends on DT_HAS_NXP_KINETIS_DAC12_ENABLED
+	help
+	  Enable the driver for the NXP Kinetis MCUX DAC.
+
 config DAC_MCUX_DAC32
 	bool "NXP Kinetis MCUX DAC32 driver"
 	default y

--- a/drivers/dac/dac_mcux_dac12.c
+++ b/drivers/dac/dac_mcux_dac12.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025 PHYTEC America LLC
+ * Author: Florijan Plohl <florijan.plohl@norik.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT nxp_kinetis_dac12
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/dac.h>
+#include <zephyr/logging/log.h>
+
+#include <fsl_dac12.h>
+
+LOG_MODULE_REGISTER(dac_mcux_dac12, CONFIG_DAC_LOG_LEVEL);
+
+struct mcux_dac12_config {
+	DAC_Type *base;
+	dac12_reference_voltage_source_t reference;
+	bool buffered;
+	bool low_power;
+};
+
+struct mcux_dac12_data {
+	bool configured;
+};
+
+static int mcux_dac12_channel_setup(const struct device *dev,
+				    const struct dac_channel_cfg *channel_cfg)
+{
+	const struct mcux_dac12_config *config = dev->config;
+	struct mcux_dac12_data *data = dev->data;
+	dac12_config_t dac12_config;
+
+	if (channel_cfg->channel_id != 0) {
+		LOG_ERR("unsupported channel %d", channel_cfg->channel_id);
+		return -ENOTSUP;
+	}
+
+	if (channel_cfg->resolution != 12) {
+		LOG_ERR("unsupported resolution %d", channel_cfg->resolution);
+		return -ENOTSUP;
+	}
+
+	if (channel_cfg->internal) {
+		LOG_ERR("Internal channels not supported");
+		return -ENOTSUP;
+	}
+
+	DAC12_GetDefaultConfig(&dac12_config);
+	dac12_config.referenceVoltageSource = config->reference;
+
+	DAC12_Init(config->base, &dac12_config);
+	DAC12_Enable(config->base, true);
+
+	data->configured = true;
+
+	return 0;
+}
+
+static int mcux_dac12_write_value(const struct device *dev, uint8_t channel, uint32_t value)
+{
+	const struct mcux_dac12_config *config = dev->config;
+	struct mcux_dac12_data *data = dev->data;
+
+	if (!data->configured) {
+		LOG_ERR("channel not initialized");
+		return -EINVAL;
+	}
+
+	if (channel != 0) {
+		LOG_ERR("unsupported channel %d", channel);
+		return -ENOTSUP;
+	}
+
+	if (value >= 4096) {
+		LOG_ERR("value %d out of range", value);
+		return -EINVAL;
+	}
+
+	DAC12_SetData(config->base, value);
+
+	return 0;
+}
+
+static const struct dac_driver_api mcux_dac12_driver_api = {
+	.channel_setup = mcux_dac12_channel_setup,
+	.write_value = mcux_dac12_write_value,
+};
+
+#define TO_DAC12_VREF_SRC(val) _DO_CONCAT(kDAC12_ReferenceVoltageSourceAlt, val)
+
+#define MCUX_DAC12_INIT(n) \
+	static struct mcux_dac12_data mcux_dac12_data_##n;		\
+									\
+	static const struct mcux_dac12_config mcux_dac12_config_##n = {	\
+		.base = (DAC_Type *)DT_INST_REG_ADDR(n),		\
+		.reference =						\
+		TO_DAC12_VREF_SRC(DT_INST_PROP(n, voltage_reference)),	\
+		.buffered = DT_INST_PROP(n, buffered),			\
+	};								\
+									\
+	DEVICE_DT_INST_DEFINE(n, NULL, NULL,				\
+			&mcux_dac12_data_##n,				\
+			&mcux_dac12_config_##n,				\
+			POST_KERNEL, CONFIG_DAC_INIT_PRIORITY,		\
+			&mcux_dac12_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(MCUX_DAC12_INIT)

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -88,6 +88,15 @@
 	};
 
 	soc {
+		dac: dac@40064000 {
+			compatible = "nxp,kinetis-dac12";
+			reg = <0x40064000 0x4000>;
+			interrupts = <63 0>;
+			voltage-reference = <2>;
+			status = "disabled";
+			#io-channel-cells = <1>;
+		};
+
 		flexspi: spi@400cc000 {
 			compatible = "nxp,imx-flexspi";
 			reg = <0x400cc000 0x4000>;

--- a/dts/arm/nxp/nxp_rt11xx_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx_cm4.dtsi
@@ -62,6 +62,11 @@
 	};
 };
 
+&dac {
+	dmas = <&edma_lpsr0 0 189>;
+	dma-names = "tx";
+};
+
 &sai1 {
 	dmas = <&edma_lpsr0 0 54>, <&edma_lpsr0 0 55>;
 	dma-names = "rx", "tx";

--- a/dts/arm/nxp/nxp_rt11xx_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx_cm7.dtsi
@@ -111,6 +111,10 @@
 	};
 };
 
+&dac {
+	dmas = <&edma0 0 189>;
+	dma-names = "tx";
+};
 
 &sai1 {
 	dmas = <&edma0 0 54>, <&edma0 0 55>;

--- a/dts/arm/phytec/phycore_rt1170_mimxrt1176_cm4.dtsi
+++ b/dts/arm/phytec/phycore_rt1170_mimxrt1176_cm4.dtsi
@@ -26,6 +26,16 @@
 		nxp,m4-partition = &slot1_partition;
 		zephyr,ipc = &mailbox_b;
 	};
+
+	zephyr,user {
+		dac = <&dac>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};
+
+&dac {
+	status = "okay";
 };
 
 &lpuart1 {

--- a/dts/arm/phytec/phycore_rt1170_mimxrt1176_cm7.dtsi
+++ b/dts/arm/phytec/phycore_rt1170_mimxrt1176_cm7.dtsi
@@ -23,6 +23,16 @@
 		zephyr,cpu1-region = &ocram;
 		zephyr,ipc = &mailbox_a;
 	};
+
+	zephyr,user {
+		dac = <&dac>;
+		dac-channel-id = <0>;
+		dac-resolution = <12>;
+	};
+};
+
+&dac {
+	status = "okay";
 };
 
 &lpuart1 {

--- a/dts/bindings/dac/nxp,kinetis-dac12.yaml
+++ b/dts/bindings/dac/nxp,kinetis-dac12.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) 2025 PHYTEC America LLC
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP Kinetis MCUX DAC
+
+compatible: "nxp,kinetis-dac12"
+
+include: dac-controller.yaml
+
+properties:
+  reg:
+    required: true
+
+  voltage-reference:
+    type: int
+    required: true
+    description: DAC voltage reference select
+
+  buffered:
+    type: boolean
+    description: Enable output buffer
+
+  "#io-channel-cells":
+    const: 1
+
+io-channel-cells:
+  - output

--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -292,6 +292,11 @@ config HAS_MCUX_DAC
 	help
 	  Set if the Digital-to-Analog (DAC) module is present in the SoC.
 
+config HAS_MCUX_DAC12
+	bool
+	help
+	  Set if the Digital-to-Analog (DAC12) module is present in the SoC.
+
 config HAS_MCUX_DAC32
 	bool
 	help

--- a/soc/nxp/imxrt/imxrt11xx/Kconfig
+++ b/soc/nxp/imxrt/imxrt11xx/Kconfig
@@ -42,6 +42,7 @@ config SOC_SERIES_IMXRT11XX
 	select HAS_MCUX_SRC_V2
 	select HAS_MCUX_IOMUXC
 	select HAS_MCUX_XBARA
+	select HAS_MCUX_DAC12
 	select HAS_SWO
 	select HAS_PM
 


### PR DESCRIPTION
Add DAC support for phycore_rt1170. 

Includes driver for DAC and device-tree definitions since they are not present in Zephyr.
Tested with `samples/drivers/dac` and also includes overlay file for phyboard_atlas.

This uses mcux-sdk driver, that is a part of NXP HAL module. There's an additional change that needs to be done there, but that isn't a part of this repository.