### PR TITLE
boards: phyboard_atlas: Fix cm4 uart

### DIFF
--- a/boards/phytec/phyboard_atlas/phyboard_atlas_mimxrt1176_cm4.dts
+++ b/boards/phytec/phyboard_atlas/phyboard_atlas_mimxrt1176_cm4.dts
@@ -14,8 +14,8 @@
 	compatible = "phytec,phyboard_atlas";
 
 	chosen {
-		zephyr,console = &lpuart1;
-		zephyr,shell-uart = &lpuart1;
+		zephyr,console = &lpuart6;
+		zephyr,shell-uart = &lpuart6;
 	};
 };
 
@@ -35,7 +35,7 @@
 	status = "okay";
 };
 
-&lpuart1 {
+&lpuart6 {
 	status = "okay";
 	current-speed = <115200>;
 };

--- a/dts/arm/phytec/phycore_rt1170_mimxrt1176_cm4.dtsi
+++ b/dts/arm/phytec/phycore_rt1170_mimxrt1176_cm4.dtsi
@@ -22,13 +22,13 @@
 		 */
 		zephyr,sram = &sram1;
 		zephyr,flash-controller = &mx25u12832f;
-		zephyr,flash = &sram0;
+		zephyr,flash = &ocram;
 		nxp,m4-partition = &slot1_partition;
 		zephyr,ipc = &mailbox_b;
 	};
 };
 
-&lpuart1 {
+&lpuart6 {
 	status = "okay";
 	current-speed = <115200>;
 };


### PR DESCRIPTION
Replaced cm4 dts to use lpuart6 instead of lpuart1. Also replaced cm4 zephyr,flash to use ocram instead of sram0 which was incorrect. 

Tested on main zephyr using: `west build -p -b phyboard_atlas/mimxrt1176/cm4 --sysbuild samples/hello_world`. `--sysbuild ` gives an error on zephyr-phytec repository that affects other boards also.